### PR TITLE
Process worker tasks in parallel to unblock LIST_TORRENTS

### DIFF
--- a/src/services/tasks-fetcher.ts
+++ b/src/services/tasks-fetcher.ts
@@ -53,14 +53,16 @@ export class TasksFetcher {
         },
       })
 
-      for (const task of response.data) {
-        try {
-          const result = await taskProcessor.process(task)
-          await this.taskDone(task.id, task.type, result)
-        } catch (error) {
-          console.error(`Failed to process task ${task.id} (${task.type}):`, error?.message)
-        }
-      }
+      await Promise.all(
+        response.data.map(async (task) => {
+          try {
+            const result = await taskProcessor.process(task)
+            await this.taskDone(task.id, task.type, result)
+          } catch (error) {
+            console.error(`Failed to process task ${task.id} (${task.type}):`, error?.message)
+          }
+        })
+      )
     } catch (error) {
       console.log("Can't fetch tasks", error?.message)
     }


### PR DESCRIPTION
## Summary

- Replace the sequential await loop in `TasksFetcher.getTasks` with `Promise.all`, so a long-running task (e.g. an `ADD_TORRENT` waiting on `filesList` metadata polling, which can back off for ~23 minutes) no longer blocks a `LIST_TORRENTS` queued behind it in the same batch.
- Tracker hands out the whole pending batch atomically and flips them all to `processing`, so later fetch ticks return empty until everything in the batch resolves — that's why "⏳ Получаю список загрузок..." was hanging.

## Test plan

- [ ] Queue an `ADD_TORRENT` for a slow-metadata magnet, then tap «📂 Мои загрузки» — expect the list to come back within seconds, well before the add finishes.
- [ ] Confirm normal single-task flows (ADD_TORRENT alone, LIST_TORRENTS alone) still complete and report `/task-done` correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtc5gV5iRYyeAAuARLxVAm)_