### PR TITLE
Always report task completion and add request timeouts

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -2,13 +2,14 @@ import axios, {AxiosError, AxiosInstance} from 'axios'
 
 const MAX_RETRIES = 3
 const BASE_DELAY_MS = 1000
+const REQUEST_TIMEOUT_MS = 30000
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export function createHttpClient(baseURL: string): AxiosInstance {
-  const client = axios.create({baseURL})
+  const client = axios.create({baseURL, timeout: REQUEST_TIMEOUT_MS})
 
   client.interceptors.response.use(undefined, async (error: AxiosError) => {
     const config = error.config as any

--- a/src/services/tasks-fetcher.ts
+++ b/src/services/tasks-fetcher.ts
@@ -53,17 +53,16 @@ export class TasksFetcher {
         },
       })
 
-      await Promise.all(
-        response.data.map(async (task) => {
-          try {
-            const result = await taskProcessor.process(task)
-            await this.taskDone(task.id, task.type, result)
-          } catch (error) {
-            console.error(`Failed to process task ${task.id} (${task.type}):`, error?.message)
-          }
-        })
-      )
-    } catch (error) {
+      for (const task of response.data) {
+        let result: TaskCompletePayload = undefined
+        try {
+          result = await taskProcessor.process(task)
+        } catch (error: any) {
+          console.error(`Failed to process task ${task.id} (${task.type}):`, error?.message)
+        }
+        await this.taskDone(task.id, task.type, result)
+      }
+    } catch (error: any) {
       console.log("Can't fetch tasks", error?.message)
     }
   }
@@ -72,7 +71,7 @@ export class TasksFetcher {
     console.log('Task complete:', JSON.stringify({id, type, payload}))
     try {
       await this.httpClient.post('/task-done', {id, type, payload})
-    } catch (error) {
+    } catch (error: any) {
       console.error(`Failed to report task ${id} completion:`, error?.message)
     }
   }

--- a/src/services/transmission-rpc.ts
+++ b/src/services/transmission-rpc.ts
@@ -5,12 +5,14 @@ type RpcResponse = {
   arguments?: Record<string, any>
 }
 
+const REQUEST_TIMEOUT_MS = 15000
+
 export class TransmissionRPC {
   private sessionId = ''
   private readonly client: AxiosInstance
 
   constructor(baseUrl: string) {
-    this.client = axios.create({baseURL: baseUrl})
+    this.client = axios.create({baseURL: baseUrl, timeout: REQUEST_TIMEOUT_MS})
   }
 
   async request(method: string, args: Record<string, any> = {}): Promise<RpcResponse> {


### PR DESCRIPTION
## Summary

After the immediate `⏳ Получаю список загрузок...` ack, the worker reply never arrived. Two worker bugs combine to wedge `LIST_TORRENTS`:

1. **Worker only reports `/task-done` on the success path.** If `taskProcessor.process` throws (e.g. a transient Transmission RPC error), the worker silently moves on. The tracker leaves the task in `processing` forever, the monitor only watches `pending`, the user gets nothing.
2. **Neither the Transmission RPC client nor the tracker HTTP client has a timeout.** A hung Transmission RPC will hang `transmission.listAll()` indefinitely, blocking the entire task-fetcher loop on that single await.

The previous parallel-processing change didn't address either root cause, so it's reverted here in favour of the actual fix.

## What changed

- Restore the original sequential task loop in `TasksFetcher.getTasks`, but always call `taskDone()` afterwards (success path passes the processor result; failure path passes `undefined`).
- Add a 15s timeout to `TransmissionRPC` so an unresponsive Transmission surfaces as an error.
- Add a 30s timeout to the tracker HTTP client so a stuck tracker call doesn't pin the loop.

## Test plan

- [ ] Stop Transmission, tap «📂 Мои загрузки» — expect a reply within ~15s (the empty-list message), not an indefinite hang.
- [ ] Normal flow with Transmission up returns the list as before.
- [ ] Confirm `ADD_TORRENT` and `SELECT_FILE` task-done reporting still works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtc5gV5iRYyeAAuARLxVAm)_