### PR TITLE
Remove torrent priority selection

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -16,11 +16,6 @@ export type DeleteFilesTaskPayload = {
   hash: string
 }
 
-export type SetPriorityTaskPayload = {
-  hash: string
-  priority: number
-}
-
 export type TorrentListItem = {
   name: string
   hash: string
@@ -29,7 +24,6 @@ export type TorrentListItem = {
   progress: string | null
   downloadedSize: string | null
   estimatedTime: string | null
-  priority?: number
 }
 
 export const enum TaskType {
@@ -38,7 +32,6 @@ export const enum TaskType {
   GET_STATUS,
   DELETE_FILES,
   LIST_TORRENTS,
-  SET_PRIORITY,
 }
 
 type TaskBase = {
@@ -65,18 +58,13 @@ type DeleteFilesTask = TaskBase & {
   payload: DeleteFilesTaskPayload
 }
 
-type SetPriorityTask = TaskBase & {
-  type: TaskType.SET_PRIORITY
-  payload: SetPriorityTaskPayload
-}
-
 type ListTorrentsTask = TaskBase & {
   type: TaskType.LIST_TORRENTS
 }
 
-export type TaskPayload = AddTorrentTaskPayload | SelectFileTaskPayload | DeleteFilesTaskPayload | SetPriorityTaskPayload
+export type TaskPayload = AddTorrentTaskPayload | SelectFileTaskPayload | DeleteFilesTaskPayload
 
-export type Task = AddTorrentTask | SelectFileTask | GetStatusTask | DeleteFilesTask | SetPriorityTask | ListTorrentsTask
+export type Task = AddTorrentTask | SelectFileTask | GetStatusTask | DeleteFilesTask | ListTorrentsTask
 
 export type AddTorrentResult = {
   hash: string
@@ -109,12 +97,6 @@ type DeleteFilesCompleteMessage = {
   payload: void
 }
 
-type SetPriorityCompleteMessage = {
-  id: number
-  type: TaskType.SET_PRIORITY
-  payload: void
-}
-
 type ListTorrentsCompleteMessage = {
   id: number
   type: TaskType.LIST_TORRENTS
@@ -134,7 +116,6 @@ export type TaskCompleteMessage =
   | SelectFileCompleteMessage
   | GetStatusCompleteMessage
   | DeleteFilesCompleteMessage
-  | SetPriorityCompleteMessage
   | ListTorrentsCompleteMessage
 
 export type TorrentProgress = {

--- a/src/services/task-processor.ts
+++ b/src/services/task-processor.ts
@@ -3,7 +3,6 @@ import {
   AddTorrentResult,
   DeleteFilesTaskPayload,
   SelectFileTaskPayload,
-  SetPriorityTaskPayload,
   Task,
   TaskCompletePayload,
   TaskType,
@@ -25,8 +24,6 @@ export class TaskProcessor {
         return this.deleteFiles(task.payload)
       case TaskType.LIST_TORRENTS:
         return this.listTorrents()
-      case TaskType.SET_PRIORITY:
-        return this.setPriority(task.payload)
     }
   }
 
@@ -55,10 +52,6 @@ export class TaskProcessor {
 
   async listTorrents(): Promise<TorrentListItem[]> {
     return await transmission.listAll()
-  }
-
-  async setPriority({hash, priority}: SetPriorityTaskPayload): Promise<void> {
-    await transmission.setBandwidthPriority(hash, priority)
   }
 }
 

--- a/src/services/transmission-service.ts
+++ b/src/services/transmission-service.ts
@@ -70,10 +70,6 @@ export class TransmissionService {
     await transmissionRpc.request('torrent-remove', {ids: [hash], 'delete-local-data': true})
   }
 
-  async setBandwidthPriority(hash: string, priority: number): Promise<void> {
-    await transmissionRpc.request('torrent-set', {ids: [hash], bandwidthPriority: priority})
-  }
-
   private readonly maxAttempts = 30
   private readonly attemptStepMS = 3000
 
@@ -114,7 +110,7 @@ export class TransmissionService {
 
   async listAll(): Promise<TorrentListItem[]> {
     const res = await transmissionRpc.request('torrent-get', {
-      fields: ['name', 'hashString', 'totalSize', 'status', 'percentDone', 'eta', 'haveValid', 'bandwidthPriority'],
+      fields: ['name', 'hashString', 'totalSize', 'status', 'percentDone', 'eta', 'haveValid'],
     })
     const torrents: any[] = res.arguments?.torrents ?? []
 
@@ -126,7 +122,6 @@ export class TransmissionService {
       progress: `${Math.round(t.percentDone * 100)}%`,
       downloadedSize: formatBytes(t.haveValid),
       estimatedTime: t.eta >= 0 ? formatEta(t.eta) : null,
-      priority: t.bandwidthPriority ?? 0,
     }))
   }
 


### PR DESCRIPTION
Убирает поддержку приоритета торрентов на стороне воркера.

- Удалены `TaskType.SET_PRIORITY`, `SetPriorityTaskPayload` и связанные complete-типы
- Удалён метод `taskProcessor.setPriority`
- Из `transmission-service` удалены `setBandwidthPriority` и запрос/возврат `bandwidthPriority`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiykVePQZBj13YgSQ1S2FV)_