### PR TITLE
Restore SET_PRIORITY task and bandwidth priority

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -16,6 +16,11 @@ export type DeleteFilesTaskPayload = {
   hash: string
 }
 
+export type SetPriorityTaskPayload = {
+  hash: string
+  priority: number
+}
+
 export type TorrentListItem = {
   name: string
   hash: string
@@ -24,6 +29,7 @@ export type TorrentListItem = {
   progress: string | null
   downloadedSize: string | null
   estimatedTime: string | null
+  priority?: number
 }
 
 export const enum TaskType {
@@ -32,6 +38,7 @@ export const enum TaskType {
   GET_STATUS,
   DELETE_FILES,
   LIST_TORRENTS,
+  SET_PRIORITY,
 }
 
 type TaskBase = {
@@ -58,13 +65,18 @@ type DeleteFilesTask = TaskBase & {
   payload: DeleteFilesTaskPayload
 }
 
+type SetPriorityTask = TaskBase & {
+  type: TaskType.SET_PRIORITY
+  payload: SetPriorityTaskPayload
+}
+
 type ListTorrentsTask = TaskBase & {
   type: TaskType.LIST_TORRENTS
 }
 
-export type TaskPayload = AddTorrentTaskPayload | SelectFileTaskPayload | DeleteFilesTaskPayload
+export type TaskPayload = AddTorrentTaskPayload | SelectFileTaskPayload | DeleteFilesTaskPayload | SetPriorityTaskPayload
 
-export type Task = AddTorrentTask | SelectFileTask | GetStatusTask | DeleteFilesTask | ListTorrentsTask
+export type Task = AddTorrentTask | SelectFileTask | GetStatusTask | DeleteFilesTask | SetPriorityTask | ListTorrentsTask
 
 export type AddTorrentResult = {
   hash: string
@@ -97,6 +109,12 @@ type DeleteFilesCompleteMessage = {
   payload: void
 }
 
+type SetPriorityCompleteMessage = {
+  id: number
+  type: TaskType.SET_PRIORITY
+  payload: void
+}
+
 type ListTorrentsCompleteMessage = {
   id: number
   type: TaskType.LIST_TORRENTS
@@ -116,6 +134,7 @@ export type TaskCompleteMessage =
   | SelectFileCompleteMessage
   | GetStatusCompleteMessage
   | DeleteFilesCompleteMessage
+  | SetPriorityCompleteMessage
   | ListTorrentsCompleteMessage
 
 export type TorrentProgress = {

--- a/src/services/task-processor.ts
+++ b/src/services/task-processor.ts
@@ -3,6 +3,7 @@ import {
   AddTorrentResult,
   DeleteFilesTaskPayload,
   SelectFileTaskPayload,
+  SetPriorityTaskPayload,
   Task,
   TaskCompletePayload,
   TaskType,
@@ -24,6 +25,8 @@ export class TaskProcessor {
         return this.deleteFiles(task.payload)
       case TaskType.LIST_TORRENTS:
         return this.listTorrents()
+      case TaskType.SET_PRIORITY:
+        return this.setPriority(task.payload)
     }
   }
 
@@ -52,6 +55,10 @@ export class TaskProcessor {
 
   async listTorrents(): Promise<TorrentListItem[]> {
     return await transmission.listAll()
+  }
+
+  async setPriority({hash, priority}: SetPriorityTaskPayload): Promise<void> {
+    await transmission.setBandwidthPriority(hash, priority)
   }
 }
 

--- a/src/services/transmission-service.ts
+++ b/src/services/transmission-service.ts
@@ -70,6 +70,10 @@ export class TransmissionService {
     await transmissionRpc.request('torrent-remove', {ids: [hash], 'delete-local-data': true})
   }
 
+  async setBandwidthPriority(hash: string, priority: number): Promise<void> {
+    await transmissionRpc.request('torrent-set', {ids: [hash], bandwidthPriority: priority})
+  }
+
   private readonly maxAttempts = 30
   private readonly attemptStepMS = 3000
 
@@ -110,7 +114,7 @@ export class TransmissionService {
 
   async listAll(): Promise<TorrentListItem[]> {
     const res = await transmissionRpc.request('torrent-get', {
-      fields: ['name', 'hashString', 'totalSize', 'status', 'percentDone', 'eta', 'haveValid'],
+      fields: ['name', 'hashString', 'totalSize', 'status', 'percentDone', 'eta', 'haveValid', 'bandwidthPriority'],
     })
     const torrents: any[] = res.arguments?.torrents ?? []
 
@@ -122,6 +126,7 @@ export class TransmissionService {
       progress: `${Math.round(t.percentDone * 100)}%`,
       downloadedSize: formatBytes(t.haveValid),
       estimatedTime: t.eta >= 0 ? formatEta(t.eta) : null,
+      priority: t.bandwidthPriority ?? 0,
     }))
   }
 


### PR DESCRIPTION
Возвращает поддержку приоритета на стороне воркера. Контроль показа кнопок — на стороне tracker (для завершённых не показывается).

- Восстановлены `TaskType.SET_PRIORITY`, `SetPriorityTaskPayload`, complete-сообщение и поле `priority` в `TorrentListItem`
- `taskProcessor.setPriority` снова вызывает `transmission.setBandwidthPriority`
- `transmission.listAll` снова запрашивает и возвращает `bandwidthPriority`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiykVePQZBj13YgSQ1S2FV)_